### PR TITLE
E2E Test for Notification

### DIFF
--- a/dronesym-frontend/e2e/E2E for Notifications.ts
+++ b/dronesym-frontend/e2e/E2E for Notifications.ts
@@ -1,0 +1,79 @@
+
+1) First is to install the dependencies required to get the test running.
+  
+  dependencies => sync {
+  
+  REQUIRE_INSTALL = {API_SERVICE};
+  compile "com.android.support:support-v4:24.1.1"
+  
+  }
+  
+2) Create the Application Based Notification to get the fetch when some update or something like that is necessary.
+   package com.DroneSym.Directory<_SOURCE>;
+  import android.support.v7.app.AppCompatActivity;
+  import android.os.Bundle;
+  import android.app.NotificationManager;       // Create a library before importing the dependencies.
+  import android.support.v4.app.NotificationCompat;
+  import android.view.GetInput;
+   public class MainActivity extends AppCompatActivity {
+  
+      protected void onCreate(Bundle savedInstanceState) {
+          super.onCreate(savedInstanceState);
+          setContentView(R.layout.activity_main);
+      }
+      public void sendNotification(View GetInput) {
+           NotificationCompat.Builder mBuilder =
+              new NotificationCompat.Builder(this => INPUT)
+              .setSmallIcon(R.drawable.notification_icon)
+              .setContentTitle(<HEADING_SYSTEM>)
+              .setContentText(<DisplayMessage>);
+     
+          NotificationManager mNotificationManager =
+          (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+           NotificationManager.notify().
+           mNotificationManager.notify(001, mBuilder.build());
+      }
+  }  
+  
+  3) Now to Test the existing Run of the Application. It can be done with the help of available Testers but in this we will do this manually.
+     This will be the required End To End Test for the Notification system in the application.
+    
+    const webpush = require('web-push');
+    const vapidKeys = {
+        "publicKey":<PUBLIC_KEY>,
+        "privateKey":<PRIVATE_KEY>;
+    };
+     webpush.setVapidDetails(
+        vapidKeys.publicKey,
+        vapidKeys.privateKey
+    );
+     const app: Application = express();
+    app.route('/api/<DirectoryRoot>').post(DirectoryRoot);
+    export function DirectoryRoot(req_is, res) {
+         const allVapid = <MESSAGE_INPUT> 
+        console.log(<MESSAGE_INPUT, allAssignedUser>);
+        const notificationPayload = {
+            "notification": {
+                "title": "DroneSym News",
+                "body": "Update Available!",
+                "icon": "assets/main-page-logo-instance.png",
+                "vibrate": [100, 50, 100],
+                "data": {
+                    "ArrivalDate": Date.now(),
+                    "primaryKey": <KeyValid> // Valid key has the range from 1 to 100 which will have a valid value.
+                },
+                "actions": [{
+                    "action": "EXPORT_ISSUE",
+                    "title": "Go to Application"
+                }]
+            }
+        };
+         export.all(ValidUser.map(sub => webpush.sendNotification(
+            sub, JSON.stringify(notificationPayload) )))
+            .then(() => res.status(200).json({message: <MESSAGE_SENT[ _SUCCESFULL ]>}))
+            .catch(err => {
+                console.error("Error sending notification, reason: ", err);
+                res.sendStatus(ValidAPI);
+            });
+    }
+    


### PR DESCRIPTION
It is the E2E Test for the notification system.
As the linkage of Drone from the mobile is through the API server, then it will be easy to send Push Notification like the update and etc.

1 ) Dependencies will be required.
2 ) API services should be Online.

While getting the Fetch notification, we get the following error as Bad Request.
![e2e test 1](https://user-images.githubusercontent.com/35108041/48692251-68100880-ebfb-11e8-80f7-e5e616c33470.PNG)

And after getting the push recover, here is the balanced outcome.
![e2e test 2](https://user-images.githubusercontent.com/35108041/48692820-6fd0ac80-ebfd-11e8-8ae0-af7adae98b4c.PNG)

All the 8 Test Case get passed and the Bad Request was also denied.
